### PR TITLE
Update deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,7 +20,7 @@ cf push $PAYMENTS_APP_NAME \
     -k 1024M
 
 
-PAYMENTS_HOST=$(cf app $PAYMENTS_APP_NAME | grep url | awk '{print $2}')
+PAYMENTS_HOST=$(cf app $PAYMENTS_APP_NAME | grep routes | awk '{print $2}')
 
 cf push $ORDERS_APP_NAME \
     -p applications/orders/build/libs/orders-trace-example-0.0.1-SNAPSHOT.jar \
@@ -31,7 +31,7 @@ cf push $ORDERS_APP_NAME \
 cf set-env $ORDERS_APP_NAME PAYMENTS_HOST $PAYMENTS_HOST
 cf start $ORDERS_APP_NAME
 
-ORDERS_HOST=$(cf app $ORDERS_APP_NAME | grep url | awk '{print $2}')
+ORDERS_HOST=$(cf app $ORDERS_APP_NAME | grep routes | awk '{print $2}')
 
 cf push $SHOPPING_CART_APP_NAME \
     -p applications/shopping-cart/build/libs/shopping-cart-trace-example-0.0.1-SNAPSHOT.jar \
@@ -42,7 +42,7 @@ cf push $SHOPPING_CART_APP_NAME \
 cf set-env $SHOPPING_CART_APP_NAME ORDERS_HOST $ORDERS_HOST
 cf start $SHOPPING_CART_APP_NAME
 
-SHOPPING_CART_HOST=$(cf app $SHOPPING_CART_APP_NAME | grep url | awk '{print $2}')
+SHOPPING_CART_HOST=$(cf app $SHOPPING_CART_APP_NAME | grep routes | awk '{print $2}')
 
 echo ""
 echo Run \`curl $SHOPPING_CART_HOST/checkout\` to verify that the deployment was successful.


### PR DESCRIPTION
Updated to work with new "cf app" output.
It's "routes" instead of "url":

```
Showing health and status for app shopping-cart-neven in org nevenc / space nevenc as nevenc...

name:              shopping-cart-neven
requested state:   started
instances:         1/1
usage:             1G x 1 instances
routes:            shopping-cart-neven.apps.XXXX
last uploaded:     Sun 24 Jun 22:43:01 CEST 2018
stack:             cflinuxfs2
buildpack:         client-certificate-mapper=1.6.0_RELEASE container-security-provider=1.13.0_RELEASE
                   java-buildpack=v4.12-offline-https://github.com/cloudfoundry/java-buildpack.git#5dca820 java-main
                   java-opts java-security jvmkill-agent=1.12.0_RELEASE open-jdk-...

     state     since                  cpu     memory         disk         details
#0   running   2018-06-24T20:43:45Z   47.3%   342.6M of 1G   146M of 1G   
```